### PR TITLE
[Refactor] MessgeBroker 리팩토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "m-pub-sub",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Simple pub-sub",
   "main": "dist/index.js",
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
+export * from './interfaces';
 export * from './message-broker';
 export * from './types';
-export * from './broker.interface';

--- a/src/interfaces/broker.interface.ts
+++ b/src/interfaces/broker.interface.ts
@@ -1,4 +1,4 @@
-import { MessageHandler } from './types';
+import { MessageHandler } from '../types';
 
 type Unsubscribe = () => Promise<void>;
 

--- a/src/interfaces/broker.interface.ts
+++ b/src/interfaces/broker.interface.ts
@@ -1,6 +1,4 @@
-import { MessageHandler } from '../types';
-
-type Unsubscribe = () => Promise<void>;
+import { MessageHandler, Unsubscribe } from '../types';
 
 export interface Broker<TMessage> {
     subscribe(publisherId: string, handler: MessageHandler<TMessage>): Promise<Unsubscribe>;

--- a/src/interfaces/broker.interface.ts
+++ b/src/interfaces/broker.interface.ts
@@ -2,10 +2,5 @@ import { MessageHandler, Unsubscribe } from '../types';
 
 export interface Broker<TMessage> {
     subscribe(publisherId: string, handler: MessageHandler<TMessage>): Promise<Unsubscribe>;
-
-    addPublisher(publisherId: string): Promise<void>;
-
-    removePublisher(publisherId: string): Promise<void>;
-
     publish(publisherId: string, message: TMessage): Promise<void>;
 }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -1,0 +1,2 @@
+export * from './broker.interface';
+export * from './subscription.interface';

--- a/src/interfaces/subscription.interface.ts
+++ b/src/interfaces/subscription.interface.ts
@@ -1,0 +1,6 @@
+import { MessageHandler } from '../types';
+
+export interface Subscription<TMessage> {
+    readonly id: string;
+    readonly handler: MessageHandler<TMessage>;
+}

--- a/src/message-broker.spec.ts
+++ b/src/message-broker.spec.ts
@@ -7,35 +7,12 @@ describe('MessageBroker', () => {
         broker = new MessageBroker();
     });
 
-    describe('addPublisher', () => {
-        it('새로운 발행자를 추가할 수 있다', async () => {
-            await expect(broker.addPublisher('publisher-1')).resolves.toBeUndefined();
-        });
-
-        it('이미 존재하는 발행자 ID로 추가하면 에러가 발생한다', async () => {
-            await broker.addPublisher('publisher-1');
-            await expect(broker.addPublisher('publisher-1')).rejects.toThrow('Publisher with ID publisher-1 already exists');
-        });
-    });
-
-    describe('removePublisher', () => {
-        it('존재하는 발행자를 제거할 수 있다', async () => {
-            await broker.addPublisher('publisher-1');
-            await expect(broker.removePublisher('publisher-1')).resolves.toBeUndefined();
-        });
-
-        it('존재하지 않는 발행자를 제거하려고 하면 에러가 발생한다', async () => {
-            await expect(broker.removePublisher('non-existent')).rejects.toThrow('Publisher with ID non-existent does not exist');
-        });
-    });
-
     describe('publish', () => {
         it('메시지를 구독자들에게 전달할 수 있다', async () => {
             const handler1 = jest.fn();
             const handler2 = jest.fn();
             const message = 'test message';
 
-            await broker.addPublisher('publisher-1');
             await broker.subscribe('publisher-1', handler1);
             await broker.subscribe('publisher-1', handler2);
 
@@ -44,26 +21,16 @@ describe('MessageBroker', () => {
             expect(handler1).toHaveBeenCalledWith(message);
             expect(handler2).toHaveBeenCalledWith(message);
         });
-
-        it('존재하지 않는 발행자로 메시지를 발행하려고 하면 에러가 발생한다', async () => {
-            await expect(broker.publish('non-existent', 'message')).rejects.toThrow('Publisher with ID non-existent does not exist');
-        });
     });
 
     describe('subscribe', () => {
         it('발행자의 메시지를 구독할 수 있다', async () => {
-            await broker.addPublisher('publisher-1');
             const unsubscribe = await broker.subscribe('publisher-1', jest.fn());
             expect(typeof unsubscribe).toBe('function');
         });
 
-        it('존재하지 않는 발행자를 구독하려고 하면 에러가 발생한다', async () => {
-            await expect(broker.subscribe('non-existent', jest.fn())).rejects.toThrow('Publisher with ID non-existent does not exist');
-        });
-
         it('구독 취소 후에는 메시지를 받지 않는다', async () => {
             const handler = jest.fn();
-            await broker.addPublisher('publisher-1');
             const unsubscribe = await broker.subscribe('publisher-1', handler);
 
             await broker.publish('publisher-1', 'message1');
@@ -82,7 +49,6 @@ describe('MessageBroker', () => {
             const handler1 = jest.fn().mockImplementation(() => delay(100));
             const handler2 = jest.fn().mockImplementation(() => delay(50));
 
-            await broker.addPublisher('publisher-1');
             await broker.subscribe('publisher-1', handler1);
             await broker.subscribe('publisher-1', handler2);
 

--- a/src/message-broker.ts
+++ b/src/message-broker.ts
@@ -1,11 +1,7 @@
-import { Broker } from './broker.interface';
+import { Broker } from './interfaces';
 import { MessageHandler } from './types';
 import { randomUUID } from 'node:crypto';
-
-export interface Subscription<TMessage> {
-    readonly id: string;
-    readonly handler: MessageHandler<TMessage>;
-}
+import { Subscription } from './interfaces';
 
 export class MessageBroker<TMessage> implements Broker<TMessage> {
     constructor(

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,1 +1,2 @@
 export type MessageHandler<TMessage> = (message: TMessage) => void | Promise<void>;
+export type Unsubscribe = () => Promise<void>;


### PR DESCRIPTION
## 변경사항
1. 인터페이스 구조 개선
   - 기존 `broker.interface.ts` 파일을 interfaces 디렉토리로 이동
   - 기존 `Subscription` 인터페이스를 파일로 분리하여 interfaces 디렉토리로 이동
   - Unsubscribe 타입을 types.ts로 이동

2. Message Broker 단순화
   - Publisher 관리 로직 제거 (addPublisher, removePublisher)
   - 내부 구현을 publishers에서 channels로 개념 변경
   - 불필요한 에러 처리 로직 제거

3. 테스트 코드 정리
   - Publisher 관련 테스트 케이스 제거
   - 남은 테스트 케이스들 정상 동작 확인

## 변경 이유
- 불필요한 Publisher 관리 로직을 제거하여 코드 복잡도 감소
- 인터페이스를 별도 디렉토리로 분리하여 코드 구조 개선
- 채널 기반의 단순한 구현으로 변경하여 사용성 향상

## 영향도
- 기존 Publisher 관리 메서드 사용 코드 수정 필요
  - addPublisher
  - removePublisher
- 나머지 기능(subscribe, publish)은 동일하게 동작
